### PR TITLE
colspan option

### DIFF
--- a/builder/Form.php
+++ b/builder/Form.php
@@ -167,6 +167,7 @@ class Form extends BaseForm
                     $colWidth = $colWidth * (int)($colOptions['colspan']);
                     unset($colOptions['colspan']);
                 }
+                $colWidth = (int)$colWidth;
                 Html::addCssClass($colOptions, 'col-' . $this->columnSize . '-' . $colWidth);
                 $content .= "\t" . Html::beginTag('div', $colOptions) . "\n";
                 $content .= "\t\t" . $this->parseInput($this->form, $this->model, $attribute, $settings, $index) . "\n";


### PR DESCRIPTION
add colspan option for asymmetrical forms

for example:

``` php
echo Form::widget([
    'model' => $model,
    'form' => $form,
    'columns' => 3,
    'attributes' => [
        'name' => ['type'=>Form::INPUT_TEXT, 'columnOptions'=>['colspan' => 2]],
        'age' => ['type'=>Form::INPUT_TEXT],
    ]
]);
```
