### PR TITLE
Composite keys handling

### DIFF
--- a/TabularForm.php
+++ b/TabularForm.php
@@ -175,7 +175,7 @@ class TabularForm extends BaseForm
                         Html::addCssClass($opts, 'form-control-static');
                         return Html::tag('div', $val, $opts);
                     }
-                    $i = empty($key) ? $index : $key;
+                    $i = empty($key) || is_array($key) ? $index : $key;
                     if ($model instanceof \yii\base\Model) {
                         $input = static::renderActiveInput(
                             $this->form,


### PR DESCRIPTION
Prevents "Array to string conversion" in line 183: "[{$i}]{$attribute}" when you have a composite primary key. Fix works in my Use Case(s). Please write a test or check the fix manually.