### PR TITLE
Fix for https://github.com/kartik-v/yii2-builder/issues/140

### DIFF
--- a/src/FormGrid.php
+++ b/src/FormGrid.php
@@ -9,7 +9,7 @@
 namespace kartik\builder;
 
 use yii\base\InvalidConfigException;
-use yii\bootstrap\Widget;
+use kartik\base\Widget;
 
 /**
  * FormGrid allows you to build and generate multi columnar bootstrap form layouts using a single simple array


### PR DESCRIPTION

## Scope
This pull request includes a fix for https://github.com/kartik-v/yii2-builder/issues/140 - 
FormGrid fails when used in bootstrap4 environment. 

- [ X] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-builder/blob/master/CHANGE.md)):
- Added FormGrid support for bootstrap4 (by replacing yii\bootstrap\Widget with kartik\base\Widget)
-
-

## Related Issues
https://github.com/kartik-v/yii2-builder/issues/140